### PR TITLE
Fix issues with union type queries

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ export default function infoToProjection(info, context = (info.fieldASTs || info
           selection.selectionSet.selections
         ) {
           nodeSelection = selection.selectionSet.selections.find(
-            sel => sel.name.value === 'node'
+            sel => sel.name && sel.name.value && sel.name.value === 'node'
           )
         }
 

--- a/test/MongoDBMockup.js
+++ b/test/MongoDBMockup.js
@@ -2,20 +2,28 @@ import users from './users.json'
 
 export default class MongoDBMockup {
   static findOne(query, projection) {
-    let result = users.find((user) => {
-      if (query._id === user._id) {
-        return user
-      } else {
-        return {}
-      }
-    })
+    let result = users.filter(user => user._id === query._id );
+    result = result.length ? result.shift() : {};
+
+    if ( result.friends ) {
+      result.friends = result.friends.map(friend => (users.filter(user => user._id === friend ).shift()))
+    }
 
     if (projection) {
       return this.projection(result, projection)
     } else {
       return result
     }
+  }
 
+  static find(query, projection) {
+    let result = users;
+
+    if (projection) {
+      return result.map(entry => this.projection(entry, projection))
+    } else {
+      return result
+    }
   }
 
   static projection(result, projection) {

--- a/test/test.js
+++ b/test/test.js
@@ -41,4 +41,56 @@ describe('Projection Tests', function() {
         assert.ok(!user.lastname)
       })
   })
+
+  it('All Fields with Union Type', function() {
+    let query = `
+      {
+        people {
+          ... on UnnamedUser {
+            _id
+            email
+          }
+
+          ... on User {
+            _id
+            email
+            firstname
+          }
+        }
+      }
+    `
+    return graphql(schema, query).then(result => {
+        let people = result.data.people
+        assert.notEqual(people, null)
+        assert.equal(people.length, 4)
+      })
+  })
+
+  it('Nested Fields with Union Type', function() {
+    let query = `
+    {
+      user(_id: "583f1607bf98f7f846e7d2d2") {
+        _id
+        email
+        firstname
+        lastname
+        friends {
+          ... on UnnamedUser {
+            _id
+            email
+          }
+
+          ... on User {
+            _id
+            firstname
+          }
+        }
+      }
+    }
+    `
+    return graphql(schema, query).then(result => {
+        let user = result.data.user
+        assert.equal(typeof result.errors, 'undefined')
+      })
+  })
 })

--- a/test/users.json
+++ b/test/users.json
@@ -9,12 +9,21 @@
     "_id": "583f1607bf98f7f846e7d2d2",
     "email":"bradpitt@mail.com",
     "firstname":"Brad",
-    "lastname":"Pitt"
+    "lastname":"Pitt",
+    "friends": [
+      "583f1607bf98f7f846e7d2d1",
+      "583f1607bf98f7f846e7d2d3",
+      "583f1607bf98f7f846e7d2d4"
+    ]
   },
   {
     "_id": "583f1607bf98f7f846e7d2d3",
     "email":"christianbale@mail.com",
     "firstname":"Christian",
     "lastname":"Bale"
+  },
+  {
+    "_id": "583f1607bf98f7f846e7d2d4",
+    "email":"johndoe@mail.com"
   }
 ]


### PR DESCRIPTION
I'm working on a small app using GraphQL and MongoDB. While testing this handy package I noticed that it doesn't work well together with union types. I guess it's because of the additional nesting (`... on AType`, `... on BType`).

This PR addresses this and adds some tests for it as well. The actual fix is just 1 changed line in `infoToProjection()`.

It would be great if you could incorporate this and publish a new version on npm.

Thanks!